### PR TITLE
Room name in "about to start" notification

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -842,5 +842,8 @@
     <string name="twitter_stream_error">Couldn\'t load the Twitter feed.</string>
     <string name="empty_twitter_stream">No posts found.</string>
     <string name="description_compose">New post</string>
+
+    <string name="room_session_notification" translatable="false">%s: %s</string>
+
 </resources>
 


### PR DESCRIPTION
# Before

In the "about to start" notification in case of a single starred session, the session name was displayed in both the title and in the text of the notification (here in the handheld and wear notification):
![device-2014-10-19-121243](https://cloud.githubusercontent.com/assets/3942812/4692935/61aaa774-5781-11e4-9500-ca583cfcd9e0.png) 
![device-2014-10-19-121254](https://cloud.githubusercontent.com/assets/3942812/4692937/6562f902-5781-11e4-8968-b03ca64b5077.png)

And in case of multiple starred sessions: 
![device-2014-10-19-120035](https://cloud.githubusercontent.com/assets/3942812/4692942/9137f960-5781-11e4-85b2-f44713fbe9eb.png)
![device-2014-10-19-120131](https://cloud.githubusercontent.com/assets/3942812/4692944/a56acb56-5781-11e4-84c9-97c57c2fdc2e.png)
# After

Display the room name for every starred session in the "about to start" notification, providing a faster way to know where to go.
With single starred session:
![device-2014-10-19-120901](https://cloud.githubusercontent.com/assets/3942812/4692951/cf7fcd24-5781-11e4-8e7e-bb691febe9c1.png)
![device-2014-10-19-120944](https://cloud.githubusercontent.com/assets/3942812/4692953/d774c674-5781-11e4-9fea-b2798ea943cb.png)

With multiple starred sessions:
![device-2014-10-19-120322](https://cloud.githubusercontent.com/assets/3942812/4692947/c52fab0a-5781-11e4-9902-a475ff12fb5e.png)
![device-2014-10-19-120336](https://cloud.githubusercontent.com/assets/3942812/4692948/c8971e68-5781-11e4-9a16-efdff091eb8b.png)
