### PR TITLE
Never show "I/O hunt" in menu when browsing sessions for a time slot

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/ui/BrowseSessionsActivity.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/ui/BrowseSessionsActivity.java
@@ -495,6 +495,7 @@ public class BrowseSessionsActivity extends BaseActivity implements SessionsFrag
             menu.removeItem(R.id.menu_wifi);
             menu.removeItem(R.id.menu_debug);
             menu.removeItem(R.id.menu_about);
+            menu.removeItem(R.id.menu_i_o_hunt);
             if(!canHandleMapOption()) {
                 menu.removeItem(R.id.menu_map);
             }


### PR DESCRIPTION
Previously the "I/O Hunt" menu item was shown unconditionally in the menu of the screen to browse sessions for one particular time slot. See here:

![iosched_io_hunt_menu_item](https://cloud.githubusercontent.com/assets/218061/4910992/e7286320-6486-11e4-9ed5-bcb796a296d8.png)

In my opinion the "I/O Hunt" menu item should never be shown in this screen like almost all of the menu items are not shown. So this pull request unconditionally removes it.
