### PR TITLE
Don't show "Map" in menu when configured to use external map

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/ui/SessionDetailActivity.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/ui/SessionDetailActivity.java
@@ -51,6 +51,7 @@ import com.bumptech.glide.request.bitmap.RequestListener;
 import com.bumptech.glide.request.target.Target;
 import com.google.android.gms.plus.PlusOneButton;
 import com.google.android.youtube.player.YouTubeIntents;
+import com.google.samples.apps.iosched.BuildConfig;
 import com.google.samples.apps.iosched.Config;
 import com.google.samples.apps.iosched.R;
 import com.google.samples.apps.iosched.model.TagMetadata;
@@ -1085,6 +1086,10 @@ public class SessionDetailActivity extends BaseActivity implements
         getMenuInflater().inflate(R.menu.session_detail, menu);
         mSocialStreamMenuItem = menu.findItem(R.id.menu_social_stream);
         mShareMenuItem = menu.findItem(R.id.menu_share);
+        if (BuildConfig.USE_EXTERNAL_MAPS) {
+            menu.removeItem(R.id.menu_map_room);
+        }
+
         tryExecuteDeferredUiOperations();
         return true;
     }


### PR DESCRIPTION
The map option is only useful when using an internal map that includes room information.

Before:
![iosched_with_map_menu_item](https://cloud.githubusercontent.com/assets/218061/4911421/4ea34b22-648d-11e4-8506-ef50022af0b7.png)

After:
![iosched_without_map_menu_item](https://cloud.githubusercontent.com/assets/218061/4911423/53d85808-648d-11e4-9d04-8a613bb8b071.png)
