### PR TITLE
Allow more lines of text for titles of break slots

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/appwidget/ScheduleWidgetRemoteViewsService.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/appwidget/ScheduleWidgetRemoteViewsService.java
@@ -212,8 +212,6 @@ public class ScheduleWidgetRemoteViewsService extends RemoteViewsService {
                     rv.setOnClickFillInIntent(R.id.box, fillIntent);
 
                 } else if (item.type == ScheduleItem.BREAK) {
-                    rv.setImageViewResource(R.id.background_image, R.drawable.schedule_item_break);
-
                     rv.setTextViewText(R.id.slot_title, item.title);
                     rv.setTextColor(R.id.slot_title, mContext.getResources().getColor(R.color.body_text_1));
 

--- a/android/src/main/java/com/google/samples/apps/iosched/ui/MyScheduleAdapter.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/ui/MyScheduleAdapter.java
@@ -281,7 +281,13 @@ public class MyScheduleAdapter implements ListAdapter, AbsListView.RecyclerListe
             view.setTag(R.id.myschedule_uri_tagkey, uri);
 
         } else if (item.type == ScheduleItem.BREAK) {
-            view.getLayoutParams().height = isPastDuringConference ? heightPast : heightBreak;
+            if (isPastDuringConference) {
+                view.getLayoutParams().height = heightPast;
+                slotTitleView.setMaxLines(sessionTitleMaxLines);
+            } else {
+                view.getLayoutParams().height = heightBreak;
+                slotTitleView.setMaxLines(breakTitleMaxLines);
+            }
             boxView.setBackgroundResource(R.drawable.schedule_item_break);
             boxView.setForeground(null);
             bgImageView.setVisibility(View.GONE);
@@ -292,7 +298,6 @@ public class MyScheduleAdapter implements ListAdapter, AbsListView.RecyclerListe
             slotTitleView.setText(item.title);
             slotTitleView.setTextColor(res.getColor(R.color.body_text_1));
             slotTitleView.setTypeface(Typeface.SANS_SERIF, Typeface.NORMAL);
-            slotTitleView.setMaxLines(breakTitleMaxLines);
             if (slotSubtitleView != null) {
                 slotSubtitleView.setText(item.subtitle);
                 slotSubtitleView.setTextColor(res.getColor(R.color.body_text_2));

--- a/android/src/main/java/com/google/samples/apps/iosched/ui/MyScheduleAdapter.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/ui/MyScheduleAdapter.java
@@ -207,6 +207,8 @@ public class MyScheduleAdapter implements ListAdapter, AbsListView.RecyclerListe
         int heightNormal = res.getDimensionPixelSize(R.dimen.my_schedule_item_height);
         int heightBreak = ViewGroup.LayoutParams.WRAP_CONTENT;
         int heightPast = res.getDimensionPixelSize(R.dimen.my_schedule_item_height_past);
+        int sessionTitleMaxLines = res.getInteger(R.integer.my_schedule_session_title_max_lines);
+        int breakTitleMaxLines = res.getInteger(R.integer.my_schedule_break_title_max_lines);
 
         long now = UIUtils.getCurrentTime(view.getContext());
         boolean showEndTime = false;
@@ -269,6 +271,7 @@ public class MyScheduleAdapter implements ListAdapter, AbsListView.RecyclerListe
             slotTitleView.setText(R.string.browse_sessions);
             slotTitleView.setTextColor(res.getColor(R.color.theme_primary));
             slotTitleView.setTypeface(Typeface.SANS_SERIF, Typeface.NORMAL);
+            slotTitleView.setMaxLines(sessionTitleMaxLines);
             if (slotSubtitleView != null) {
                 slotSubtitleView.setText(item.subtitle);
                 slotSubtitleView.setTextColor(res.getColor(R.color.body_text_2));
@@ -289,6 +292,7 @@ public class MyScheduleAdapter implements ListAdapter, AbsListView.RecyclerListe
             slotTitleView.setText(item.title);
             slotTitleView.setTextColor(res.getColor(R.color.body_text_1));
             slotTitleView.setTypeface(Typeface.SANS_SERIF, Typeface.NORMAL);
+            slotTitleView.setMaxLines(breakTitleMaxLines);
             if (slotSubtitleView != null) {
                 slotSubtitleView.setText(item.subtitle);
                 slotSubtitleView.setTextColor(res.getColor(R.color.body_text_2));
@@ -349,6 +353,7 @@ public class MyScheduleAdapter implements ListAdapter, AbsListView.RecyclerListe
                     ? Color.WHITE
                     : res.getColor(R.color.body_text_1_inverse));
             mLUtils.setMediumTypeface(slotTitleView);
+            slotTitleView.setMaxLines(sessionTitleMaxLines);
             if (slotSubtitleView != null) {
                 slotSubtitleView.setText(item.subtitle);
                 slotSubtitleView.setTextColor(res.getColor(R.color.body_text_2_inverse));

--- a/android/src/main/res/layout/my_schedule_item.xml
+++ b/android/src/main/res/layout/my_schedule_item.xml
@@ -92,12 +92,13 @@
             <TextView
                 android:id="@+id/slot_title"
                 android:layout_width="wrap_content"
-                android:layout_height="36dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
                 android:gravity="bottom"
                 android:text="@string/placeholder_session_title"
                 android:textSize="@dimen/text_size_large"
                 android:ellipsize="end"
-                android:maxLines="1" />
+                android:maxLines="@integer/my_schedule_session_title_max_lines" />
 
             <TextView
                 android:id="@+id/slot_subtitle"

--- a/android/src/main/res/layout/widget_schedule_item_break.xml
+++ b/android/src/main/res/layout/widget_schedule_item_break.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-
 <!--
   Copyright 2014 Google Inc. All rights reserved.
 
@@ -16,15 +14,71 @@
   limitations under the License.
   -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_height="wrap_content"
-    android:layout_width="match_parent">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:paddingBottom="8dp"
+              android:paddingLeft="@dimen/keyline_1"
+              android:paddingRight="@dimen/keyline_1"
+              android:orientation="horizontal"
+              android:layout_height="wrap_content"
+              android:layout_width="match_parent">
 
-    <include
-        layout="@layout/widget_schedule_item"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+    <!--Start and end times -->
 
-    </include>
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="@dimen/widget_schedule_time_width"
+        android:layout_height="match_parent">
 
-</FrameLayout>
+        <TextView
+            android:id="@+id/start_time"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:gravity="bottom"
+            android:textSize="@dimen/text_size_medium"
+            android:textColor="@color/body_text_2"/>
+
+        <TextView
+            android:id="@+id/end_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/text_size_small"
+            android:textColor="@color/body_text_3"/>
+
+        <TextView
+            android:id="@+id/conflict_warning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/text_size_small"
+            android:textColor="@color/my_schedule_conflict"
+            android:text="@string/schedule_conflict_with_previous"
+            android:visibility="invisible"/>
+    </LinearLayout>
+
+    <!-- Block/slot chip contents -->
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                 android:id="@+id/box"
+                 android:layout_width="0dp"
+                 android:layout_weight="1"
+                 android:layout_height="match_parent"
+                 android:background="@drawable/schedule_item_break"
+                 android:paddingLeft="16dp"
+                 android:paddingRight="8dp"
+                 android:paddingTop="12dp"
+                 android:paddingBottom="12dp">
+
+        <TextView
+            android:id="@+id/slot_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/text_size_large"
+            android:ellipsize="end"
+            android:maxLines="3"/>
+
+        <TextView
+            android:id="@+id/slot_subtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/text_size_small"/>
+
+    </LinearLayout>
+</LinearLayout>

--- a/android/src/main/res/values/integers.xml
+++ b/android/src/main/res/values/integers.xml
@@ -30,4 +30,7 @@
     <!-- Number of grid columns spanned by the hero on wide layout.
     Recommended: 1 less than explore_1st_level_grid_columns -->
     <integer name="explore_wide_layout_hero_weight">1</integer>
+
+    <integer name="my_schedule_session_title_max_lines">1</integer>
+    <integer name="my_schedule_break_title_max_lines">3</integer>
 </resources>


### PR DESCRIPTION
Allow up to 3 lines of text for titles of break slots since there is no detail view for them where users can see the full title.

Before:
![iosched_break_title_before__cropped](https://cloud.githubusercontent.com/assets/218061/4912216/34dc84bc-649a-11e4-86dc-f2596f6cf211.png)

After:
![iosched_break_title_after__cropped](https://cloud.githubusercontent.com/assets/218061/4912217/3a4438dc-649a-11e4-90c2-8625b13de3c5.png)
