### PR TITLE
Fix crash when recreating views of reused MyScheduleFragments

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/ui/MyScheduleFragment.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/ui/MyScheduleFragment.java
@@ -48,6 +48,12 @@ public class MyScheduleFragment extends ListFragment {
         return mRoot;
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        setListAdapter(null);
+    }
+
     public void setContentDescription(String desc) {
         mContentDescription = desc;
         if (mRoot != null) {


### PR DESCRIPTION
Fix the following crash when recreating views for reused fragments in the "My Schedule" screen.

```
java.lang.IllegalStateException: Cannot add header view to list -- setAdapter has already been called.
  at android.widget.ListView.addHeaderView(ListView.java:265)
  at android.widget.ListView.addHeaderView(ListView.java:294)
  at com.google.samples.apps.iosched.ui.MyScheduleActivity.onFragmentViewCreated(MyScheduleActivity.java:371)
  at com.google.samples.apps.iosched.ui.MyScheduleFragment.onViewCreated(MyScheduleFragment.java:62)
  …
```

Crashes on a test device with Android 4.3 when showing 3 conference days. Seems to have been fixed in newer Android versions.
